### PR TITLE
Support Venafi Cloud & Remove API functions

### DIFF
--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -2,27 +2,27 @@
 # Official VCert documentation for details on these settings:
 # https://support.venafi.com/hc/en-us/articles/360037087552-Info-Venafi-Trust-Protection-Platform-19-4-Is-Released
 
-# Universal Settings
-cn = "my_common_name"
-zone = "my_zone"
-renew-threshold = 14
-expiry-check = 1
+    # Universal Settings
+    cn = "my_common_name"
+    zone = "my_zone"
+    renew-threshold = 14
+    expiry-check = 1
 
-# Venafi TPP-Only Settings
-[tpp]
-    [tpp.auth]
-    # url = "my_url"
-    # user = "my_username"
-    # password = "my_password"
-    # token = "my_token"
+    # Venafi TPP-Only Settings
+    # [tpp]
+    #     [tpp.auth]
+        # url = "my_url"
+        # user = "my_username"
+        # password = "my_password"
+        # token = "my_token"
 
-    [tpp.device]
-    register = "false"
-    # tls_port = 443
-    # tls_address = "myapp.example.com"
-    # app-name = "my_app"
-    # app-info = "my_app_info"
+        # [tpp.device]
+        # register = "false"
+        # tls_port = 443
+        # tls_address = "myapp.example.com"
+        # app-name = "my_app"
+        # app-info = "my_app_info"
 
-# Venafi Cloud-Only Settings
-# [cloud.auth]
-    # apikey = "my_apikey"
+    # Venafi Cloud-Only Settings
+    # [cloud.auth]
+        # apikey = "my_apikey"

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,17 +1,28 @@
-# This file contains the variables needed for configuring the service
-# url: The url to your Venafi SDK endpoint (e.g. "https://bla.dev.lab.venafi.com/vedsdk")
-# user: The username you use to authenticate with the sdk
-# password: The password you use to authenticate with the sdk
-# cn: The common name of your certificate (e.g. "bla.example.com")
-# zone: The zone of your certificate (e.g. "Certificates\\\\Bla")
-# renew-threshold: The amount of days away from the expiry date to trigger a renewal request
-# expiry-check: The interval for checking how close the day is to the 'renew-threshold' date, in days
+# This file contains the variables needed for configuring the service. See README or 
+# Official VCert documentation for details on these settings:
+# https://support.venafi.com/hc/en-us/articles/360037087552-Info-Venafi-Trust-Protection-Platform-19-4-Is-Released
 
-[tpp]
-url = "my_url"
-user = "my_username"
-password = "my_password"
+# Universal Settings
 cn = "my_common_name"
 zone = "my_zone"
 renew-threshold = 14
 expiry-check = 1
+
+# Venafi TPP-Only Settings
+[tpp]
+    [tpp.auth]
+    # url = "my_url"
+    # user = "my_username"
+    # password = "my_password"
+    # token = "my_token"
+
+    [tpp.device]
+    register = "false"
+    # tls_port = 443
+    # tls_address = "myapp.example.com"
+    # app-name = "my_app"
+    # app-info = "my_app_info"
+
+# Venafi Cloud-Only Settings
+# [cloud.auth]
+    # apikey = "my_apikey"

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -2,59 +2,55 @@
 exec 2>&1
 
 # Set credentials
-TPP_URL="{{ cfg.tpp.url }}"
-TPP_USER="{{ cfg.tpp.user }}"
-TPP_PASSWORD="{{ cfg.tpp.password }}"
-COMMON_NAME="{{ cfg.tpp.cn }}"
-CERTIFICATE_ZONE="{{ cfg.tpp.zone }}"
+{{#unless cfg.tpp.auth.url ~}}
+TPP_URL="{{ cfg.tpp.auth.url }}"
+TPP_USER="{{ cfg.tpp.auth.user }}"
+TPP_PASSWORD="{{ cfg.tpp.auth.password }}"
+{{/unless}}
+COMMON_NAME="{{ cfg.cn }}"
+{{#unless cfg.cloud.auth.apikey ~}}
+CLOUD_APIKEY="{{ cfg.cloud.auth.apikey }}"
+{{/unless}}
 
-# Set cert file
+# Set device information
+APP_INFO="{{ cfg.tpp.device.app-info }}"
+INSTANCE="{{ sys.hostname }}{{#if cfg.tpp.device.app-name ~}}:{{ cfg.tpp.device.app-name }}{{/if ~}}"
+{{#unless cfg.tpp.device.tls_address ~}}
+TLS_ADDRESS="{{ sys.ip }}:{{ cfg.tpp.device.tls_port }}"
+{{/unless}}
+{{#if cfg.tpp.device.tls_address ~}}
+TLS_ADDRESS="{{ cfg.tpp.device.tls_address }}:{{ cfg.tpp.device.tls_port }}"
+{{/if ~}}
+
+# Set certificate file names
 CERT_FILE="${COMMON_NAME}.cert"
 KEY_FILE="${COMMON_NAME}.key"
 CHAIN_FILE="${COMMON_NAME}.chain"
+ID_FILE="${COMMON_NAME}.id"
 
 # Set cert path
 CERT_PATH="{{pkg.svc_data_path}}/${CERT_FILE}"
 KEY_PATH="{{pkg.svc_data_path}}/${KEY_FILE}"
 CHAIN_PATH="{{pkg.svc_data_path}}/${CHAIN_FILE}"
-CERT_ID="\\\\VED\\\\Policy\\\\${CERTIFICATE_ZONE}\\\\${COMMON_NAME}"
-
-HOSTNAME="{{sys.hostname}}"
-
-# Set DN paths for device and app creation
-DEVICE_CREATION_DN="\\\\VED\\\\Policy\\\\Devices And Applications\\\\External\\\\${HOSTNAME}"
-APP_CREATION_DN="\\\\VED\\\\Policy\\\\Devices And Applications\\\\External\\\\${HOSTNAME}\\\\${COMMON_NAME}-{{sys.ip}}{{sys.hostname}}"
-
-RUN_ONCE=true
+ID_PATH="{{pkg.svc_data_path}}/${ID_FILE}"
 
 # Establish a CA
 SSL_CERT_FILE="{{pkgPathFor "core/cacerts"}}/ssl/certs/cacert.pem"
 export SSL_CERT_FILE
 
+# https://support.venafi.com/hc/en-us/articles/217991528-Introducing-VCert-API-Abstraction-for-DevOps
 function enroll_new_cert() {
-    # Enroll a new SSL cert
-    exec vcert enroll -no-prompt \
-        -tpp-url ${TPP_URL} \
-        -tpp-user ${TPP_USER} \
-        -tpp-password ${TPP_PASSWORD} \
-        -cert-file ${CERT_PATH} \
-        -key-file ${KEY_PATH} \
-        -chain-file ${CHAIN_PATH} \
-        -cn ${COMMON_NAME} \
-        -z ${CERTIFICATE_ZONE}
+    exec vcert enroll -no-prompt {{#if cfg.cloud.auth.apikey ~}} -k ${CLOUD_APIKEY} {{/if ~}}{{#if cfg.tpp.auth.url ~}} -tpp-user ${TPP_USER} -tpp-password ${TPP_PASSWORD} -u ${TPP_URL} {{/if ~}} -z "{{ cfg.zone }}" -cert-file ${CERT_PATH} -key-file ${KEY_PATH} -chain-file ${CHAIN_PATH} -cn ${COMMON_NAME} -pickup-id-file ${ID_PATH} {{#if cfg.tpp.device.register ~}}-instance ${INSTANCE} -replace-instance -app-info ${APP_INFO} -tls-address ${TLS_ADDRESS}{{/if ~}}
+    
+    # TODO: This 'echo' command is filler because the "if" helper
+    # On the previous line pulls the curly brace that closes the
+    # function to the previous line (invalid shell syntax). 
+    # Remove when this is resolved.
+    echo "Proceeding to renewal check."
 }
 
 function renew_cert() {
-    # Renew the SSL cert
-    exec vcert renew -no-prompt \
-        -tpp-url ${TPP_URL} \
-        -tpp-user ${TPP_USER} \
-        -tpp-password ${TPP_PASSWORD} \
-        -cert-file ${CERT_PATH} \
-        -key-file ${KEY_PATH} \
-        -chain-file ${CHAIN_PATH} \
-        -id ${CERT_ID} \
-        -z ${CERTIFICATE_ZONE}
+    exec vcert renew -no-prompt {{#if cfg.cloud.auth.apikey ~}} -k ${CLOUD_APIKEY} {{/if ~}} {{#if cfg.tpp.auth.url ~}} -tpp-url ${TPP_URL} -tpp-user ${TPP_USER} -tpp-password ${TPP_PASSWORD} {{/if ~}} -cert-file ${CERT_PATH} -key-file ${KEY_PATH} -chain-file ${CHAIN_PATH} -id file:${ID_PATH} -z "{{ cfg.zone }}"
 }
 
 function update_cert_config() {
@@ -71,65 +67,13 @@ function update_cert_config() {
 }
 
 function check_expiry() {
-    # Use Python to extract the client token for authentication
-    tpp_token=$(curl -s -L \
-            -H 'Content-Type: application/json' \
-            -X POST \
-            -d '{"Username":"'"$TPP_USER"'","Password":"'"$TPP_PASSWORD"'"}' \
-            $TPP_URL/authorize | python -c "import sys, json; print json.load(sys.stdin)['APIKey']")
-
-    # Get Certs
-    cert_json=$(curl -s -L \
-            -H 'Content-Type: application/json' \
-            -H 'X-Venafi-API-Key: '$tpp_token \
-            $TPP_URL/certificates?cn=${COMMON_NAME})
-    echo $cert_json
-
-    valid_to=0
-    while IFS="|" read -r dn x509; do
-        if [ "$dn" = "\\VED\\Policy\\${CERTIFICATE_ZONE}\\${COMMON_NAME}" ]; then
-            # Extract only the date portion, 'date' has a weird bug of breaking on ':' from a bash script
-            valid_to=$(jq --raw-output '.ValidTo' <<< "$x509" | cut -c1-10)
-        fi
-    done< <(jq --raw-output '.Certificates[] | "\(.DN)|\(.X509)"' <<< "$cert_json")
-
-    # Convert to seconds
-    valid_to=$(exec date -d "$valid_to" +%s)
+    valid_to=$(cut -d "=" -f2 <<< $(openssl x509 -enddate -noout -in ${CERT_PATH}))
+    valid_to_epoch=$(date -d "${valid_to}" +"%s")
     curr_date=$(exec date "+%s")
-
-    if (({{ cfg.tpp.renew-threshold }} * 86400 + curr_date > valid_to)); then
+    if (({{ cfg.renew-threshold }} * 86400 + curr_date > valid_to_epoch)); then
         echo "Renewing expiring cert:"
-        renew_cert
+        renew_cert   
     fi
-}
-
-function create_dependencies() {
-    tpp_token=$(curl -s -L \
-        -H 'Content-Type: application/json' \
-        -X POST \
-        -d '{"Username":"'"$TPP_USER"'","Password":"'"$TPP_PASSWORD"'"}' \
-        $TPP_URL/authorize | python -c "import sys, json; print json.load(sys.stdin)['APIKey']")
-
-    device_creation=$(curl -s -L \
-        -H 'Content-Type: application/json' \
-        -H 'X-Venafi-API-Key: '$tpp_token \
-        -X POST \
-        -d '{ "ObjectDN": "'"$DEVICE_CREATION_DN"'", "Class": "Device", "NamedAttributeList": [ { "Name": "Description", "Value": "{{sys.hostname}} is managed by venafi-helper." } ] }' $TPP_URL/Config/Create )
-    echo $device_creation
-
-    application_creation=$(curl -s -L \
-        -H 'Content-Type: application/json' \
-        -H 'X-Venafi-API-Key: '$tpp_token \
-        -X POST \
-        -d '{ "ObjectDN": "'"$APP_CREATION_DN"'", "Class": "Basic", "NamedAttributeList": [ { "Name": "Description", "Value": "Basic app for certificate '${COMMON_NAME}'" }, { "Name": "Disabled", "Value": "0" } ] }' $TPP_URL/Config/Create )
-    echo $application_creation
-
-    associate_certs=$(curl -s -L \
-        -H 'Content-Type: application/json' \
-        -H 'X-Venafi-API-Key: '$tpp_token \
-        -X POST \
-        -d '{ "ApplicationDN": ["'"$APP_CREATION_DN"'"], "CertificateDN": "'"$CERT_ID"'" }' $TPP_URL/Certificates/Associate )
-    echo $associate_certs
 }
 
 if [ ! -f ${CERT_PATH}  ]; then
@@ -138,17 +82,8 @@ if [ ! -f ${CERT_PATH}  ]; then
     enroll_new_cert
 fi
 
-if test -f "createdeps.tmp"; then
-    create_dependencies
-    rm -f createdeps.tmp
-fi
-
 update_cert_config
 check_expiry
-sleep $(({{ cfg.tpp.expiry-check }} * 86400))
+sleep $(({{ cfg.expiry-check }} * 86400))
 
-echo "Check complete. Sleeping for {{ cfg.tpp.expiry-check }} days"
-
-{{#each cfg.servers as |server| ~}}
-   echo "{{server.apache.zone}}"
-{{/each ~}}
+echo "Check complete. Sleeping for {{ cfg.expiry-check }} days"

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -84,6 +84,5 @@ fi
 
 update_cert_config
 check_expiry
-sleep $(({{ cfg.expiry-check }} * 86400))
-
 echo "Check complete. Sleeping for {{ cfg.expiry-check }} days"
+sleep $(({{ cfg.expiry-check }} * 86400))

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -2,15 +2,15 @@
 exec 2>&1
 
 # Set credentials
-{{#unless cfg.tpp.auth.url ~}}
+{{#if cfg.tpp.auth.url ~}}
 TPP_URL="{{ cfg.tpp.auth.url }}"
 TPP_USER="{{ cfg.tpp.auth.user }}"
 TPP_PASSWORD="{{ cfg.tpp.auth.password }}"
-{{/unless}}
+{{/if}}
 COMMON_NAME="{{ cfg.cn }}"
-{{#unless cfg.cloud.auth.apikey ~}}
+{{#if cfg.cloud.auth.apikey ~}}
 CLOUD_APIKEY="{{ cfg.cloud.auth.apikey }}"
-{{/unless}}
+{{/if}}
 
 # Set device information
 APP_INFO="{{ cfg.tpp.device.app-info }}"

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -7,6 +7,7 @@ pkg_deps=(
   core/curl
   core/python2
   core/glibc
+  core/openssl
   core/cacerts
   core/jq-static
   indellient/vcert

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=venafi-helper
 pkg_origin=indellient
-pkg_version="0.3.0"
+pkg_version="0.4.1"
 pkg_license=("Apache-2.0")
 
 pkg_deps=(

--- a/vcert/habitat/plan.sh
+++ b/vcert/habitat/plan.sh
@@ -1,10 +1,10 @@
 pkg_name=vcert
 pkg_origin=indellient
-pkg_version="4.1.0"
+pkg_version="4.9.6"
 pkg_license=("Apache-2.0")
-pkg_source="https://github.com/Venafi/${pkg_name}/releases/download/v${pkg_version}/vcert86_linux"
+pkg_source="https://github.com/Venafi/vcert/releases/download/v4.9.6/vcert-v4.9.6+895_linux86"
 pkg_filename="vcert"
-pkg_shasum="f16ce62802bde9d9ecc23a42911575b193d09fb6fadf84a6a7991a11a8a2b257"
+pkg_shasum="6be4059df6faadd2da21aebc01ce1f8942b5107cc909cc05bf2c430044983152"
 pkg_deps=(core/glibc core/gcc-libs)
 pkg_bin_dirs=(bin)
 pkg_description="Venafi helper tool for managing SSL certs"


### PR DESCRIPTION
This PR allows the end user to use Venafi Cloud as a replacement for Venafi Trust Protection platform if needed (TPP still supported). Because API calls differ between both platforms, all API calls were removed.

Previously we were using API-based functions for:
- Device Registration
- Expiry Check

This PR alters the approach to use `openssl` to check expiry date and `vcert` to handle device registration.

Other Changes:
- `vcert` Habitat package is now pinned to latest stable release because we cannot use `pkg_version` due to [vcert release URLs being inconsistent](https://github.com/Venafi/vcert/releases). Newer version was required for device registration flags.
- Organized toml configuration by platform
- Device registration is now optional (`cfg.tpp.device.register = true/false`)

**To Do:**
- Renew functionality is broken for Venafi Cloud (waiting on response from Venafi)
- Document toml settings in README