### PR TITLE
Force app-info/origin to be statically set for the integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ expiry-check = 1
 	tls_port = 443
 	tls_address = "myapp.example.com"
 	app-name = "my_app"
-	app-info = "my_app_info"
 ```
 
 Or cloud:

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -21,7 +21,6 @@
         # tls_port = 443
         # tls_address = "myapp.example.com"
         # app-name = "my_app"
-        # app-info = "my_app_info"
 
     # Venafi Cloud-Only Settings
     # [cloud.auth]

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -14,7 +14,7 @@ CLOUD_APIKEY="{{ cfg.cloud.auth.apikey }}"
 {{/if}}
 
 # Set device information
-APP_INFO="{{ cfg.tpp.device.app-info }}"
+APP_INFO="Indellient-ChefHabitat-Helper"
 INSTANCE="{{ sys.hostname }}{{#if cfg.tpp.device.app-name ~}}:{{ cfg.tpp.device.app-name }}{{/if ~}}"
 {{#unless cfg.tpp.device.tls_address ~}}
 TLS_ADDRESS="{{ sys.ip }}:{{ cfg.tpp.device.tls_port }}"


### PR DESCRIPTION
Based on discussion with Paul:
> 
> I talked with the maintainers of the CLI a little bit and it looks like the Origin field is available, there’s just a name difference in the parameter in the CLI vs the SDK… So, the good news is that it’s available now. In the CLI, it’s referred to as --app-info


This modifies the existing support by hard-coding the app-info flag from the integration.